### PR TITLE
set tailored logzio alert title url in slack notification msg

### DIFF
--- a/models/labels.go
+++ b/models/labels.go
@@ -24,6 +24,7 @@ const (
 	// StateReasonAnnotation is the name of the annotation that explains the difference between evaluation state and alert state (i.e. changing state when NoData or Error).
 	StateReasonAnnotation = GrafanaReservedLabelPrefix + "state_reason"
 
-	ValuesAnnotation      = "__values__"
-	ValueStringAnnotation = "__value_string__"
+	ValuesAnnotation          = "__values__"
+	ValueStringAnnotation     = "__value_string__"
+	LogzioAccountIdAnnotation = "__logzioAccountId__" //LOGZ.IO GRAFANA CHANGE :: DEV-43657: set correct app urls on notifications
 )

--- a/receivers/slack/slack.go
+++ b/receivers/slack/slack.go
@@ -300,7 +300,8 @@ func (sn *Notifier) createSlackMessage(ctx context.Context, alerts []*types.Aler
 	var tmplErr error
 	tmpl, _ := templates.TmplText(ctx, sn.tmpl, alerts, sn.log, &tmplErr)
 
-	ruleURL := receivers.JoinURLPath(sn.tmpl.ExternalURL.String(), "/alerting/list", sn.log)
+	basePath := receivers.ToBasePathWithAccountRedirect(sn.tmpl.ExternalURL, alerts)                //LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
+	ruleURL := receivers.ToLogzioAppPath(receivers.JoinURLPath(basePath, "/alerting/list", sn.log)) // LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
 
 	// If all alerts have the same GeneratorURL, use that.
 	if sn.commonAlertGeneratorURL(ctx, alerts) {

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/grafana/alerting/models"
+	"github.com/prometheus/alertmanager/types"
 	"io"
 	"net"
 	"net/http"
@@ -26,6 +28,8 @@ const (
 
 	AlertStateAlerting AlertStateType = "alerting"
 	AlertStateOK       AlertStateType = "ok"
+
+	EncodedHashSymbol = "%23" // LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
 )
 
 func GetAlertStatusColor(status model.AlertStatus) string {
@@ -110,6 +114,45 @@ func JoinURLPath(base, additionalPath string, logger logging.Logger) string {
 
 	return u.String()
 }
+
+// LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
+
+func ToLogzioAppPath(path string) string {
+	// because the app path contains # symbol which is encoded by default we need to replace encoded symbol back to original
+	return strings.Replace(path, EncodedHashSymbol, "#", 1)
+}
+
+func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
+	const LogzioSwitchToAccountQueryParamName = "switchToAccountId"
+	updatedUrl := *u
+	builder := strings.Builder{}
+
+	builder.WriteString(u.RawQuery)
+
+	if accountId != "" {
+		if builder.Len() > 0 {
+			builder.WriteString("&")
+		}
+
+		builder.WriteString(LogzioSwitchToAccountQueryParamName)
+		builder.WriteString("=")
+		builder.WriteString(accountId)
+	}
+
+	updatedUrl.RawQuery = builder.String()
+	return &updatedUrl
+}
+
+func ToBasePathWithAccountRedirect(path *url.URL, as []*types.Alert) string {
+	var accountId = ""
+	if len(as) > 0 {
+		accountId = string(as[0].Annotations[models.LogzioAccountIdAnnotation])
+	}
+
+	return AppendSwitchToAccountQueryParam(path, accountId).String()
+}
+
+// LOGZ.IO GRAFANA CHANGE :: end
 
 // GetBoundary is used for overriding the behaviour for tests
 // and set a boundary for multipart Body. DO NOT set this outside tests.

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/grafana/alerting/models"
-	"github.com/prometheus/alertmanager/types"
+	"github.com/grafana/alerting/models"       // LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
+	"github.com/prometheus/alertmanager/types" // LOGZ.IO GRAFANA CHANGE :: DEV-43657 - Set logzio APP URLs for the URLs inside alert notifications
 	"io"
 	"net"
 	"net/http"

--- a/receivers/util.go
+++ b/receivers/util.go
@@ -123,7 +123,7 @@ func ToLogzioAppPath(path string) string {
 }
 
 func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
-	const LogzioSwitchToAccountQueryParamName = "switchToAccountId"
+	const logzioSwitchToAccountQueryParamName = "switchToAccountId"
 	updatedUrl := *u
 	builder := strings.Builder{}
 
@@ -134,7 +134,7 @@ func AppendSwitchToAccountQueryParam(u *url.URL, accountId string) *url.URL {
 			builder.WriteString("&")
 		}
 
-		builder.WriteString(LogzioSwitchToAccountQueryParamName)
+		builder.WriteString(logzioSwitchToAccountQueryParamName)
 		builder.WriteString("=")
 		builder.WriteString(accountId)
 	}


### PR DESCRIPTION
this PR adds the switchToAccount query param with the needed account to the alert title url in the slack notification.